### PR TITLE
Add clone methods to the token providers

### DIFF
--- a/tests/test_token_provider.py
+++ b/tests/test_token_provider.py
@@ -1,6 +1,11 @@
 import pytest
+import respx
 
 import h2o_authn
+
+TEST_CLIENT_ID = "test-client-id"
+TEST_CLIENT_SECRET = "test-client-secret"
+TOKEN_ENDPOINT_URL = "http://example.com/token"
 
 
 @pytest.mark.parametrize(
@@ -30,3 +35,125 @@ def test_token_provider_constructor_atleast_one_url_required(constructor):
 
     # Then
     assert "argument is required" in str(exc_info.value)
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_sync_token_provider_as_async():
+    # Given
+    route = respx.post(
+        TOKEN_ENDPOINT_URL,
+        data={
+            "grant_type": "refresh_token",
+            "client_id": TEST_CLIENT_ID,
+            "refresh_token": "input_refresh_token",
+            "client_secret": TEST_CLIENT_SECRET,
+            "scope": "input scope",
+        },
+    ).respond(json={"access_token": "new_access_token"})
+
+    provider = h2o_authn.TokenProvider(
+        refresh_token="input_refresh_token",
+        client_id=TEST_CLIENT_ID,
+        client_secret=TEST_CLIENT_SECRET,
+        token_endpoint_url=TOKEN_ENDPOINT_URL,
+        scope="input scope",
+    )
+
+    # When
+    async_provider = provider.as_async()
+    _ = await async_provider()
+
+    # Then
+    assert route.called
+
+
+@respx.mock
+def test_async_token_provider_as_sync():
+    # Given
+    route = respx.post(
+        TOKEN_ENDPOINT_URL,
+        data={
+            "grant_type": "refresh_token",
+            "client_id": TEST_CLIENT_ID,
+            "refresh_token": "input_refresh_token",
+            "client_secret": TEST_CLIENT_SECRET,
+            "scope": "input scope",
+        },
+    ).respond(json={"access_token": "new_access_token"})
+
+    provider = h2o_authn.AsyncTokenProvider(
+        refresh_token="input_refresh_token",
+        client_id=TEST_CLIENT_ID,
+        client_secret=TEST_CLIENT_SECRET,
+        token_endpoint_url=TOKEN_ENDPOINT_URL,
+        scope="input scope",
+    )
+
+    # When
+    async_provider = provider.as_sync()
+    _ = async_provider()
+
+    # Then
+    assert route.called
+
+
+@respx.mock
+def test_sync_token_provider_with_scope():
+    # Given
+    route = respx.post(
+        TOKEN_ENDPOINT_URL,
+        data={
+            "grant_type": "refresh_token",
+            "client_id": TEST_CLIENT_ID,
+            "refresh_token": "input_refresh_token",
+            "client_secret": TEST_CLIENT_SECRET,
+            "scope": "new scope",
+        },
+    ).respond(json={"access_token": "new_access_token"})
+
+    provider = h2o_authn.TokenProvider(
+        refresh_token="input_refresh_token",
+        client_id=TEST_CLIENT_ID,
+        client_secret=TEST_CLIENT_SECRET,
+        token_endpoint_url=TOKEN_ENDPOINT_URL,
+        scope="input scope",
+    )
+
+    # When
+    new_provider = provider.with_scope("new scope")
+    _ = new_provider()
+
+    # Then
+    assert route.called
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_async_token_provider_with_scope():
+    # Given
+    route = respx.post(
+        TOKEN_ENDPOINT_URL,
+        data={
+            "grant_type": "refresh_token",
+            "client_id": TEST_CLIENT_ID,
+            "refresh_token": "input_refresh_token",
+            "client_secret": TEST_CLIENT_SECRET,
+            "scope": "new scope",
+        },
+    ).respond(json={"access_token": "new_access_token"})
+
+    provider = h2o_authn.AsyncTokenProvider(
+        refresh_token="input_refresh_token",
+        client_id=TEST_CLIENT_ID,
+        client_secret=TEST_CLIENT_SECRET,
+        token_endpoint_url=TOKEN_ENDPOINT_URL,
+        scope="input scope",
+    )
+
+    # When
+    new_provider = provider.with_scope("new scope")
+    _ = await new_provider()
+
+    # Then
+    assert route.called


### PR DESCRIPTION
 - allows to create sync/async variants with the same configuration
 - create a new instance for the different scope.