### PR TITLE
chore: 💚 remove pip caching from the release WF

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -24,7 +24,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.7"
-          cache: 'pip'
 
       - name: Upgrade pip
         run: |


### PR DESCRIPTION
python action caching depends on existance of requirements.txt file
and it breaks with our repo.
Release is not run often enyways so we can live without cache.
