### PR TITLE
chore: 💚 use poetry sessioon for lint

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
   pull_request:
     paths-ignore:
-      - '**.md'
+      - "**.md"
 jobs:
   test:
     name: Test
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-python@v4
         id: setup-python
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install pypa/build
         run: |
@@ -34,7 +34,6 @@ jobs:
       - name: Build a binary wheel and a source tarball
         run: |
           python -m build
-
 
   lint:
     name: Lint
@@ -47,7 +46,7 @@ jobs:
         uses: actions/setup-python@v4
         id: setup-python
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - uses: actions/cache@v3
         with:

--- a/src/h2o_authn/token.py
+++ b/src/h2o_authn/token.py
@@ -34,7 +34,6 @@ class Container:
         expires_in_fallback: datetime.timedelta = DEFAULT_EXPIRES_IN_FALLBACK,
         minimal_expires_in: Optional[datetime.timedelta] = None,
     ) -> None:
-
         self._original_access_token = refresh_token
         self._refresh_token = refresh_token
         self._original_access_token = refresh_token


### PR DESCRIPTION
Lint step/job was hanging when run on github actions. This was most
likely cause by pip backtracking to install flake8 plugins.
Using version pinned by poetry should fix this.
