### PR TITLE
chore: 💚 use poetry sessioon for lint

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -10,7 +10,7 @@ def tests(session, httpx):
     session.run("pytest", *session.posargs)
 
 
-@nox.session()
+@nox_poetry.session()
 def lint(session):
     session.install(".")
     session.install("black", "mypy")

--- a/src/h2o_authn/token.py
+++ b/src/h2o_authn/token.py
@@ -34,7 +34,6 @@ class Container:
         expires_in_fallback: datetime.timedelta = DEFAULT_EXPIRES_IN_FALLBACK,
         minimal_expires_in: Optional[datetime.timedelta] = None,
     ) -> None:
-
         self._original_access_token = refresh_token
         self._refresh_token = refresh_token
         self._original_access_token = refresh_token


### PR DESCRIPTION
Lint step/job was hanging when run on github actions. This was most
likely cause by pip backtracking to install flake8 plugins.
Using version pinned by poetry should fix this.
