### PR TITLE
feat: ✨ optionally support creation of token providers from discovery objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,3 +126,53 @@ client = h2osteam.clients.DriverlessClient()
 
 ...
 ```
+
+### H2O Cloud Discovery support
+
+I you use token providers to access H2O.ai services running on H2O Cloud, you
+can simplify the configuration by using `h2o-authn[discovery]` extra.
+
+For more info regarding H2O Cloud Discovery, please see
+[H2O Cloud Discovery Client](https://github.com/h2oai/cloud-discovery-py)
+
+```sh
+pip install h2o-authn[discovery]
+```
+
+Module `h2o_authn.discovery` provides `new` and `new_async` functions which
+accepts following arguments:
+
+- `discovery`: The Discovery object to use for configuration.
+- `client`: The name of the client to use for configuration.
+    Defaults to "platform".
+- `service`: The name of the service to use for configuration to use for scope
+    inference. Scope is used in the token requests. Ignored if scope is set.
+- `scope`: The scope to use for the token requests.
+- `expiry_threshold`: How long before token expiration should token be
+    refreshed when needed. This does not mean that the token will be
+    refreshed before it expires, only indicates the earliest moment before
+    the expiration when refresh would occur. (default: 5s)
+- `expires_in_fallback`: Fallback value for the expires_in value. Will be used
+    when token response does not contains expires_in field.
+- `minimal_refresh_period`: Optionally minimal period between the earliest token
+    refresh exchanges.
+
+#### Example: Use of the H2O Cloud Discovery with H2O.ai MLOps Python CLient
+
+```python
+
+import h2o_authn.discovery
+import h2o_discovery
+import h2o_mlops_client as mlops
+
+
+discovery = h2o_discovery.discover()
+
+provider = h2o_authn.discovery.new(discovery, service="mlops")
+
+mlops_client = mlops.Client(
+    gateway_url=discovery.services["mlops"].uri,
+    token_provider=provider,
+)
+...
+```

--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ client = h2osteam.clients.DriverlessClient()
 
 ### H2O Cloud Discovery support
 
-I you use token providers to access H2O.ai services running on H2O Cloud, you
-can simplify the configuration by using `h2o-authn[discovery]` extra.
+I you use the token provider to access H2O.ai services running in your  H2O AI Cloud environment, you
+can simply the configuration by using `h2o-authn[discovery]` extension.
 
 For more info regarding H2O Cloud Discovery, please see
 [H2O Cloud Discovery Client](https://github.com/h2oai/cloud-discovery-py)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,15 +31,7 @@ Source = "https://github.com/h2oai/authn-py"
 packages = ["src/h2o_authn"]
 
 [project.optional-dependencies]
-# TODO(@zoido): Set to released version once available.
-# DO NOT MERGE
-# discovery = ["h2o-cloud-discovery~=1.1"]
-discovery = ["h2o-cloud-discovery @ https://s3.amazonaws.com/artifacts.h2o.ai/snapshots/ai/h2o/cloud-discovery/h2o_cloud_discovery-1.1.0.dev5-py3-none-any.whl"]
-
-[tool.hatch.metadata]
-# TODO(@zoido): Remove once the released discovery version is set above
-# DO NOT MERGE
-allow-direct-references = true
+discovery = ["h2o-cloud-discovery~=1.1"]
 
 [[tool.hatch.envs.test.matrix]]
 httpx = ["httpx0.16", "httpx0.21", "httpx0.22", "httpx0.23"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,11 +27,19 @@ Documentation = "https://github.com/h2oai/authn-py#readme"
 Issues = "https://github.com/h2oai/authn-py/issues"
 Source = "https://github.com/h2oai/authn-py"
 
-[tool.hatch.build.targets.sdist]
-include = ["/src", "/tests", "CHANGELOG.md"]
-
 [tool.hatch.build.targets.wheel]
 packages = ["src/h2o_authn"]
+
+[project.optional-dependencies]
+# TODO(@zoido): Set to released version once available.
+# DO NOT MERGE
+# discovery = ["h2o-cloud-discovery~=1.1"]
+discovery = ["h2o-cloud-discovery @ https://s3.amazonaws.com/artifacts.h2o.ai/snapshots/ai/h2o/cloud-discovery/h2o_cloud_discovery-1.1.0.dev5-py3-none-any.whl"]
+
+[tool.hatch.metadata]
+# TODO(@zoido): Remove once the released discovery version is set above
+# DO NOT MERGE
+allow-direct-references = true
 
 [[tool.hatch.envs.test.matrix]]
 httpx = ["httpx0.16", "httpx0.21", "httpx0.22", "httpx0.23"]
@@ -53,13 +61,14 @@ dependencies = [
   "time-machine~=2.10",
 ]
 dev-mode = false
+features = ["discovery"]
 
 [tool.hatch.envs.test.scripts]
 pytest = "python -m pytest {args}"
 
 [tool.hatch.envs.devtest]
-template = "test"
 dev-mode = true
+template = "test"
 
 [tool.hatch.envs.lint]
 dependencies = [
@@ -67,6 +76,7 @@ dependencies = [
   "mypy~=1.1",
   "ruff==0.0.286",
 ]
+features = ["discovery"]
 
 [tool.hatch.envs.lint.scripts]
 check = [

--- a/src/h2o_authn/discovery.py
+++ b/src/h2o_authn/discovery.py
@@ -1,0 +1,113 @@
+import datetime
+from typing import Optional
+
+import h2o_discovery
+
+from h2o_authn import provider
+
+DEFAULT_CLIENT = "platform"
+
+
+def new(
+    discovery: h2o_discovery.Discovery,
+    client: str = DEFAULT_CLIENT,
+    *,
+    service: Optional[str] = None,
+    scope: Optional[str] = None,
+    client_secret: Optional[str] = None,
+    expiry_threshold: datetime.timedelta = provider.DEFAULT_EXPIRY_THRESHOLD,
+    expires_in_fallback: datetime.timedelta = provider.DEFAULT_EXPIRES_IN_FALLBACK,
+    minimal_refresh_period: Optional[datetime.timedelta] = None,
+):
+    """Returns a new TokenProvider instance configured from the given Discovery object.
+
+    By default the provider will be configured to use the "platform".
+
+    Args:
+        discovery: The Discovery object to use for configuration.
+        client: The name of the client to use for configuration.
+            Defaults to "platform".
+        service: The name of the service to use for configuration to use for scope
+            inference. Scope is used in the token requests. Ignored if scope is set.
+        scope: The scope to use for the token requests.
+        expiry_threshold: How long before token expiration should token be
+            refreshed when needed. This does not mean that the token will be
+            refreshed before it expires, only indicates the earliest moment before
+            the expiration when refresh would occur. (default: 5s)
+        expires_in_fallback: Fallback value for the expires_in value. Will be used
+            when token response does not contains expires_in field.
+        minimal_refresh_period: Optionally minimal period between the earliest token
+            refresh exchanges.
+    """
+
+    client_id = discovery.clients[client].oauth2_client_id
+    issuer_url = discovery.environment.issuer_url
+    refresh_token = discovery.credentials[client].refresh_token
+
+    set_scope = scope
+    if not set_scope and service:
+        set_scope = discovery.services[service].oauth2_scope
+
+    return provider.TokenProvider(
+        refresh_token=refresh_token,
+        client_id=client_id,
+        issuer_url=issuer_url,
+        client_secret=client_secret,
+        scope=set_scope,
+        expiry_threshold=expiry_threshold,
+        expires_in_fallback=expires_in_fallback,
+        minimal_refresh_period=minimal_refresh_period,
+    )
+
+
+def new_async(
+    discovery: h2o_discovery.Discovery,
+    client: str = DEFAULT_CLIENT,
+    *,
+    service: Optional[str] = None,
+    scope: Optional[str] = None,
+    client_secret: Optional[str] = None,
+    expiry_threshold: datetime.timedelta = provider.DEFAULT_EXPIRY_THRESHOLD,
+    expires_in_fallback: datetime.timedelta = provider.DEFAULT_EXPIRES_IN_FALLBACK,
+    minimal_refresh_period: Optional[datetime.timedelta] = None,
+):
+    """Returns a new AsyncTokenProvider instance configured from the given Discovery
+    object.
+
+    By default the provider will be configured to use the "platform".
+
+    Args:
+        discovery: The Discovery object to use for configuration.
+        client: The name of the client to use for configuration.
+            Defaults to "platform".
+        service: The name of the service to use for configuration to use for scope
+            inference. Scope is used in the token requests. Ignored if scope is set.
+        scope: The scope to use for the token requests.
+        expiry_threshold: How long before token expiration should token be
+            refreshed when needed. This does not mean that the token will be
+            refreshed before it expires, only indicates the earliest moment before
+            the expiration when refresh would occur. (default: 5s)
+        expires_in_fallback: Fallback value for the expires_in value. Will be used
+            when token response does not contains expires_in field.
+        minimal_refresh_period: Optionally minimal period between the earliest token
+            refresh exchanges.
+    """
+
+    client_id = discovery.clients[client].oauth2_client_id
+    issuer_url = discovery.environment.issuer_url
+    refresh_token = discovery.credentials[client].refresh_token
+
+    set_scope = scope
+    if not set_scope and service:
+        set_scope = discovery.services[service].oauth2_scope
+
+    return provider.AsyncTokenProvider(
+        refresh_token=refresh_token,
+        client_id=client_id,
+        issuer_url=issuer_url,
+        client_secret=client_secret,
+        scope=set_scope,
+        expiry_threshold=expiry_threshold,
+        expires_in_fallback=expires_in_fallback,
+        minimal_refresh_period=minimal_refresh_period,
+    )

--- a/src/h2o_authn/discovery.py
+++ b/src/h2o_authn/discovery.py
@@ -8,7 +8,7 @@ from h2o_authn import provider
 DEFAULT_CLIENT = "platform"
 
 
-def new(
+def create(
     discovery: h2o_discovery.Discovery,
     client: str = DEFAULT_CLIENT,
     *,
@@ -59,7 +59,7 @@ def new(
     )
 
 
-def new_async(
+def create_async(
     discovery: h2o_discovery.Discovery,
     client: str = DEFAULT_CLIENT,
     *,

--- a/src/h2o_authn/discovery.py
+++ b/src/h2o_authn/discovery.py
@@ -12,7 +12,6 @@ def create(
     discovery: h2o_discovery.Discovery,
     client: str = DEFAULT_CLIENT,
     *,
-    service: Optional[str] = None,
     scope: Optional[str] = None,
     client_secret: Optional[str] = None,
     expiry_threshold: datetime.timedelta = provider.DEFAULT_EXPIRY_THRESHOLD,
@@ -27,8 +26,6 @@ def create(
         discovery: The Discovery object to use for configuration.
         client: The name of the client to use for configuration.
             Defaults to "platform".
-        service: The name of the service to use for configuration to use for scope
-            inference. Scope is used in the token requests. Ignored if scope is set.
         scope: The scope to use for the token requests.
         expiry_threshold: How long before token expiration should token be
             refreshed when needed. This does not mean that the token will be
@@ -43,9 +40,6 @@ def create(
     client_id = discovery.clients[client].oauth2_client_id
     issuer_url = discovery.environment.issuer_url
     refresh_token = discovery.credentials[client].refresh_token
-
-    if not scope and service:
-        scope = discovery.services[service].oauth2_scope
 
     return provider.TokenProvider(
         refresh_token=refresh_token,
@@ -63,7 +57,6 @@ def create_async(
     discovery: h2o_discovery.Discovery,
     client: str = DEFAULT_CLIENT,
     *,
-    service: Optional[str] = None,
     scope: Optional[str] = None,
     client_secret: Optional[str] = None,
     expiry_threshold: datetime.timedelta = provider.DEFAULT_EXPIRY_THRESHOLD,
@@ -79,8 +72,6 @@ def create_async(
         discovery: The Discovery object to use for configuration.
         client: The name of the client to use for configuration.
             Defaults to "platform".
-        service: The name of the service to use for configuration to use for scope
-            inference. Scope is used in the token requests. Ignored if scope is set.
         scope: The scope to use for the token requests.
         expiry_threshold: How long before token expiration should token be
             refreshed when needed. This does not mean that the token will be
@@ -96,16 +87,12 @@ def create_async(
     issuer_url = discovery.environment.issuer_url
     refresh_token = discovery.credentials[client].refresh_token
 
-    set_scope = scope
-    if not set_scope and service:
-        set_scope = discovery.services[service].oauth2_scope
-
     return provider.AsyncTokenProvider(
         refresh_token=refresh_token,
         client_id=client_id,
         issuer_url=issuer_url,
         client_secret=client_secret,
-        scope=set_scope,
+        scope=scope,
         expiry_threshold=expiry_threshold,
         expires_in_fallback=expires_in_fallback,
         minimal_refresh_period=minimal_refresh_period,

--- a/src/h2o_authn/discovery.py
+++ b/src/h2o_authn/discovery.py
@@ -44,16 +44,15 @@ def new(
     issuer_url = discovery.environment.issuer_url
     refresh_token = discovery.credentials[client].refresh_token
 
-    set_scope = scope
-    if not set_scope and service:
-        set_scope = discovery.services[service].oauth2_scope
+    if not scope and service:
+        scope = discovery.services[service].oauth2_scope
 
     return provider.TokenProvider(
         refresh_token=refresh_token,
         client_id=client_id,
         issuer_url=issuer_url,
         client_secret=client_secret,
-        scope=set_scope,
+        scope=scope,
         expiry_threshold=expiry_threshold,
         expires_in_fallback=expires_in_fallback,
         minimal_refresh_period=minimal_refresh_period,

--- a/tests/test_token_provider_suite.py
+++ b/tests/test_token_provider_suite.py
@@ -229,32 +229,7 @@ class ProviderFromDiscoveryWithExplicitClient(AbstractTestCase):
         assert self.token_route.called
 
 
-class ProviderFromDiscoveryWithServiceScope(AbstractTestCase):
-    def given(self):
-        self.issuer_discovery_route = respx.get(ISSUER_DISCOVERY_URL).respond(
-            json={"token_endpoint": TOKEN_ENDPOINT_URL}
-        )
-
-        self.token_route = respx.post(
-            TOKEN_ENDPOINT_URL,
-            data={
-                "grant_type": "refresh_token",
-                "client_id": PLATFORM_CLIENT_ID,
-                "refresh_token": PLATFORM_CLIENT_REFRESH_TOKEN,
-                "scope": "test service scopes",
-            },
-        ).respond(json={"access_token": "new_access_token"})
-
-        self.provider = self.create_provider_from_discovery(
-            discovery=TEST_DISCOVERY, service="test-service"
-        )
-
-    def then(self):
-        assert self.issuer_discovery_route.called
-        assert self.token_route.called
-
-
-class ProviderFromDiscoveryWithExplicitScope(AbstractTestCase):
+class ProviderFromDiscoveryWithScope(AbstractTestCase):
     def given(self):
         self.issuer_discovery_route = respx.get(ISSUER_DISCOVERY_URL).respond(
             json={"token_endpoint": TOKEN_ENDPOINT_URL}

--- a/tests/test_token_provider_suite.py
+++ b/tests/test_token_provider_suite.py
@@ -77,7 +77,7 @@ class SyncTestCase:
 
     @staticmethod
     def create_provider_from_discovery(*args, **kwargs):
-        return h2o_authn.discovery.new(*args, **kwargs)
+        return h2o_authn.discovery.create(*args, **kwargs)
 
     def when(self):
         with time_machine.travel(0, tick=False):
@@ -93,7 +93,7 @@ class AsyncTestCase:
 
     @staticmethod
     def create_provider_from_discovery(*args, **kwargs):
-        return h2o_authn.discovery.new_async(*args, **kwargs)
+        return h2o_authn.discovery.create_async(*args, **kwargs)
 
     async def when(self):
         with time_machine.travel(0, tick=False):

--- a/tests/test_token_provider_suite.py
+++ b/tests/test_token_provider_suite.py
@@ -1,15 +1,61 @@
 import abc
 
+import h2o_discovery
+from h2o_discovery import model
 import pytest
 import respx
 import time_machine
 
 import h2o_authn
+import h2o_authn.discovery
 
 TEST_CLIENT_ID = "test-client-id"
 TOKEN_ENDPOINT_URL = "http://example.com/token"
 ISSUER_URL = "http://example.com/"
 ISSUER_DISCOVERY_URL = "http://example.com/.well-known/openid-configuration"
+
+PLATFORM_CLIENT_ID = "test-platfrom-client-id"
+PLATFORM_CLIENT_REFRESH_TOKEN = "platform_client_refresh_token"
+TEST_CLIENT_REFRESH_TOKEN = "test_client_refresh_token"
+
+TEST_DISCOVERY = h2o_discovery.Discovery(
+    environment=model.Environment(
+        issuer_url=ISSUER_URL,
+        h2o_cloud_environment="https://example.com",
+        h2o_cloud_platform_oauth2_scope="input scope",
+        h2o_cloud_version="TEST",
+    ),
+    clients={
+        "platform": model.Client(
+            name="platform",
+            oauth2_client_id=PLATFORM_CLIENT_ID,
+            display_name="Platform Test Client",
+        ),
+        "test_client": model.Client(
+            name="test_client",
+            oauth2_client_id=TEST_CLIENT_ID,
+            display_name="Test Client",
+        ),
+    },
+    services={
+        "test-service": model.Service(
+            name="test-service",
+            oauth2_scope="test service scopes",
+            display_name="Test Service",
+            uri="https://example.com",
+            python_client="test-service",
+            version="TEST",
+        )
+    },
+    credentials={
+        "platform": model.Credentials(
+            client="platform", refresh_token=PLATFORM_CLIENT_REFRESH_TOKEN
+        ),
+        "test_client": model.Credentials(
+            client="test_client", refresh_token=TEST_CLIENT_REFRESH_TOKEN
+        ),
+    },
+)
 
 
 class AbstractTestCase(abc.ABC):
@@ -24,7 +70,14 @@ class AbstractTestCase(abc.ABC):
 
 class SyncTestCase:
     provider: h2o_authn.TokenProvider
-    create_provider = h2o_authn.TokenProvider
+
+    @staticmethod
+    def create_provider(*args, **kwargs):
+        return h2o_authn.TokenProvider(*args, **kwargs)
+
+    @staticmethod
+    def create_provider_from_discovery(*args, **kwargs):
+        return h2o_authn.discovery.new(*args, **kwargs)
 
     def when(self):
         with time_machine.travel(0, tick=False):
@@ -33,7 +86,14 @@ class SyncTestCase:
 
 class AsyncTestCase:
     provider: h2o_authn.AsyncTokenProvider
-    create_provider = h2o_authn.AsyncTokenProvider
+
+    @staticmethod
+    def create_provider(*args, **kwargs):
+        return h2o_authn.AsyncTokenProvider(*args, **kwargs)
+
+    @staticmethod
+    def create_provider_from_discovery(*args, **kwargs):
+        return h2o_authn.discovery.new_async(*args, **kwargs)
 
     async def when(self):
         with time_machine.travel(0, tick=False):
@@ -99,7 +159,7 @@ class ProviderTestOptionalParamsUsed(AbstractTestCase):
 
 class ProviderTestIssuerDiscoveryUsed(AbstractTestCase):
     def given(self):
-        self.discovery_route = respx.get(ISSUER_DISCOVERY_URL).respond(
+        self.issuer_discovery_route = respx.get(ISSUER_DISCOVERY_URL).respond(
             json={"token_endpoint": TOKEN_ENDPOINT_URL}
         )
 
@@ -119,7 +179,103 @@ class ProviderTestIssuerDiscoveryUsed(AbstractTestCase):
         )
 
     def then(self):
-        assert self.discovery_route.called
+        assert self.issuer_discovery_route.called
+        assert self.token_route.called
+
+
+class ProviderFromDiscoveryWithDefaultClient(AbstractTestCase):
+    def given(self):
+        self.issuer_discovery_route = respx.get(ISSUER_DISCOVERY_URL).respond(
+            json={"token_endpoint": TOKEN_ENDPOINT_URL}
+        )
+
+        self.token_route = respx.post(
+            TOKEN_ENDPOINT_URL,
+            data={
+                "grant_type": "refresh_token",
+                "client_id": PLATFORM_CLIENT_ID,
+                "refresh_token": PLATFORM_CLIENT_REFRESH_TOKEN,
+            },
+        ).respond(json={"access_token": "new_access_token"})
+
+        self.provider = self.create_provider_from_discovery(discovery=TEST_DISCOVERY)
+
+    def then(self):
+        assert self.issuer_discovery_route.called
+        assert self.token_route.called
+
+
+class ProviderFromDiscoveryWithExplicitClient(AbstractTestCase):
+    def given(self):
+        self.issuer_discovery_route = respx.get(ISSUER_DISCOVERY_URL).respond(
+            json={"token_endpoint": TOKEN_ENDPOINT_URL}
+        )
+
+        self.token_route = respx.post(
+            TOKEN_ENDPOINT_URL,
+            data={
+                "grant_type": "refresh_token",
+                "client_id": TEST_CLIENT_ID,
+                "refresh_token": TEST_CLIENT_REFRESH_TOKEN,
+            },
+        ).respond(json={"access_token": "new_access_token"})
+
+        self.provider = self.create_provider_from_discovery(
+            discovery=TEST_DISCOVERY, client="test_client"
+        )
+
+    def then(self):
+        assert self.issuer_discovery_route.called
+        assert self.token_route.called
+
+
+class ProviderFromDiscoveryWithServiceScope(AbstractTestCase):
+    def given(self):
+        self.issuer_discovery_route = respx.get(ISSUER_DISCOVERY_URL).respond(
+            json={"token_endpoint": TOKEN_ENDPOINT_URL}
+        )
+
+        self.token_route = respx.post(
+            TOKEN_ENDPOINT_URL,
+            data={
+                "grant_type": "refresh_token",
+                "client_id": PLATFORM_CLIENT_ID,
+                "refresh_token": PLATFORM_CLIENT_REFRESH_TOKEN,
+                "scope": "test service scopes",
+            },
+        ).respond(json={"access_token": "new_access_token"})
+
+        self.provider = self.create_provider_from_discovery(
+            discovery=TEST_DISCOVERY, service="test-service"
+        )
+
+    def then(self):
+        assert self.issuer_discovery_route.called
+        assert self.token_route.called
+
+
+class ProviderFromDiscoveryWithExplicitScope(AbstractTestCase):
+    def given(self):
+        self.issuer_discovery_route = respx.get(ISSUER_DISCOVERY_URL).respond(
+            json={"token_endpoint": TOKEN_ENDPOINT_URL}
+        )
+
+        self.token_route = respx.post(
+            TOKEN_ENDPOINT_URL,
+            data={
+                "grant_type": "refresh_token",
+                "client_id": PLATFORM_CLIENT_ID,
+                "refresh_token": PLATFORM_CLIENT_REFRESH_TOKEN,
+                "scope": "explicit scope",
+            },
+        ).respond(json={"access_token": "new_access_token"})
+
+        self.provider = self.create_provider_from_discovery(
+            discovery=TEST_DISCOVERY, scope="explicit scope"
+        )
+
+    def then(self):
+        assert self.issuer_discovery_route.called
         assert self.token_route.called
 
 


### PR DESCRIPTION
With recently added suuport for credentials in the discovery client (https://github.com/h2oai/cloud-discovery-py/pull/67, https://github.com/h2oai/cloud-discovery-py/pull/68, https://github.com/h2oai/cloud-discovery-py/pull/69) we can infer most of the required parameters from the discovery.

As this is additional feature with extra depdendecy I went with extra `h2o_authn[discovery]` and isolated feature in its own module, so that only explicit import imports the dependency.

Test are part of the provider suite.

RESOLVES https://github.com/h2oai/cloud-discovery/issues/443
