### PR TITLE
 REVIEW: use Union two parameters to differentiate scope source. 

### DIFF
--- a/src/h2o_authn/discovery.py
+++ b/src/h2o_authn/discovery.py
@@ -8,7 +8,7 @@ from h2o_authn import provider
 DEFAULT_CLIENT = "platform"
 
 
-def new(
+def create(
     discovery: h2o_discovery.Discovery,
     client: str = DEFAULT_CLIENT,
     *,
@@ -59,7 +59,7 @@ def new(
     )
 
 
-def new_async(
+def create_async(
     discovery: h2o_discovery.Discovery,
     client: str = DEFAULT_CLIENT,
     *,

--- a/tests/test_token_provider_suite.py
+++ b/tests/test_token_provider_suite.py
@@ -246,7 +246,8 @@ class ProviderFromDiscoveryWithServiceScope(AbstractTestCase):
         ).respond(json={"access_token": "new_access_token"})
 
         self.provider = self.create_provider_from_discovery(
-            discovery=TEST_DISCOVERY, service="test-service"
+            discovery=TEST_DISCOVERY,
+            scope=h2o_authn.discovery.ScopeForService("test-service"),
         )
 
     def then(self):

--- a/tests/test_token_provider_suite.py
+++ b/tests/test_token_provider_suite.py
@@ -77,7 +77,7 @@ class SyncTestCase:
 
     @staticmethod
     def create_provider_from_discovery(*args, **kwargs):
-        return h2o_authn.discovery.new(*args, **kwargs)
+        return h2o_authn.discovery.create(*args, **kwargs)
 
     def when(self):
         with time_machine.travel(0, tick=False):
@@ -93,7 +93,7 @@ class AsyncTestCase:
 
     @staticmethod
     def create_provider_from_discovery(*args, **kwargs):
-        return h2o_authn.discovery.new_async(*args, **kwargs)
+        return h2o_authn.discovery.create_async(*args, **kwargs)
 
     async def when(self):
         with time_machine.travel(0, tick=False):


### PR DESCRIPTION
This PR addresses https://github.com/h2oai/authn-py/pull/54/files#r1328440830 comment on https://github.com/h2oai/authn-py/pull/54

The form of PR was chosen to highlight the change and enable potential polishing an discussion.