### PR TITLE
docs: 📝 Fix discovery example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,10 +166,10 @@ import h2o_mlops_client as mlops
 
 discovery = h2o_discovery.discover()
 
-provider = h2o_authn.discovery.new(discovery, service="mlops")
+provider = h2o_authn.discovery.create(discovery, service="mlops-api")
 
 mlops_client = mlops.Client(
-    gateway_url=discovery.services["mlops"].uri,
+    gateway_url=discovery.services["mlops-api"].uri,
     token_provider=provider,
 )
 ...


### PR DESCRIPTION
 - uses porper method name (was renamed from `new` to `create` during the code review)
 - uses the proper name of the MLOps API service
