### PR TITLE
chore: 🔨 use `ruff format` instead of `black` for formatting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,32 +64,40 @@ template = "test"
 
 [tool.hatch.envs.lint]
 dependencies = [
-  "black==22.10.0",
   "mypy~=1.1",
-  "ruff==0.0.286",
+  "ruff==0.1.11",
 ]
 features = ["discovery"]
 
 [tool.hatch.envs.lint.scripts]
 check = [
-  "black --check .",
+  "ruff format --check .",
   "ruff check .",
   "mypy src",
 ]
 fix = [
   "ruff check --fix .",
-  "black .",
+  "ruff format .",
   "check",
 ]
 
-[tool.black]
-skip-magic-trailing-comma = true
+[tool.hatch.envs.docs]
+dependencies = [
+  "pydoc-markdown~=4.8",
+]
+
+[tool.hatch.envs.docs.scripts]
+generate = "pydoc-markdown"
 
 [tool.ruff]
 extend-select = ["I", "B", "A", "ERA"]
 line-length = 88 # Same as black.
 src = ["src", "test"]
 target-version = "py37"
+
+[tool.ruff.format]
+docstring-code-format = true
+skip-magic-trailing-comma = true
 
 [tool.ruff.isort]
 case-sensitive = false


### PR DESCRIPTION
[`ruff format` is available from `0.1.2`](https://docs.astral.sh/ruff/formatter/) using instead of `black`:
 - removes one dependency/tool
 - improves speed of the linting.

one trailing line added by the formatter.
