### PR TITLE
ci: 💚 fix release please work flow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,6 +27,6 @@ jobs:
     uses: ./.github/workflows/pypi-release.yml
 
     needs: release-please
-    if: needs.release-please.outputs.releases_created
+    if: needs.release-please.outputs.releases_created == 'true'
 
     secrets: inherit


### PR DESCRIPTION
fix condition so that it's evaluated as bool

Currently the release workflow executes with any commit to default branch. It fails as the upload to the PyPI fails on uniqueness constraint.
