### PR TITLE
build!: 💥 remove support for Python 3.7

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v5
         with:
-          python-version: "3.7"
+          python-version: "3.8"
 
       - name: Install pypa/build
         run: |

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ description = "H2O Python Clients Authentication Helpers"
 license = "Apache-2.0"
 name = "h2o-authn"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 version = "1.1.1"
 
 [project.urls]
@@ -35,7 +35,7 @@ discovery = ["h2o-cloud-discovery~=1.1"]
 
 [[tool.hatch.envs.test.matrix]]
 httpx = ["httpx0.16", "httpx0.21", "httpx0.22", "httpx0.23"]
-python = ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
 [tool.hatch.envs.test.overrides]
 matrix.httpx.dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ discovery = ["h2o-cloud-discovery~=1.1"]
 
 [[tool.hatch.envs.test.matrix]]
 httpx = ["httpx0.16", "httpx0.21", "httpx0.22", "httpx0.23"]
-python = ["3.7", "3.8", "3.9", "3.10", "3.11"]
+python = ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
 [tool.hatch.envs.test.overrides]
 matrix.httpx.dependencies = [


### PR DESCRIPTION
BREAKING CHANGE: Python 3.7 is no longer supported. The minimum supported version is now Python 3.8.

 - Remove official support for Python 3.7 from the package metadata.
 - Remove Python 3.7 from the CI matrix.
