### PR TITLE
feat: 🧑‍💻 Implement `__str__` for `TokenEndpointError` to provide more info in tracebacks.

### DIFF
--- a/src/h2o_authn/error.py
+++ b/src/h2o_authn/error.py
@@ -28,6 +28,14 @@ class TokenEndpointError(BaseError):
         if self.error_description:
             parts.append(f", error_description={self.error_description!r}")
         if self.error_uri:
-            parts.append(f", error_description={self.error_uri!r}")
+            parts.append(f", error_uri={self.error_uri!r}")
         parts.append(")")
+        return "".join(parts)
+
+    def __str__(self) -> str:
+        parts = [self.error]
+        if self.error_description:
+            parts.append(f": {self.error_description}")
+        if self.error_uri:
+            parts.append(f" ({self.error_uri})")
         return "".join(parts)

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -1,0 +1,97 @@
+import pytest
+
+import h2o_authn.error
+
+
+def repr_test_cases():
+    yield pytest.param(
+        "TEST_ERROR",
+        "Test Description.",
+        "https://example.com/error",
+        (
+            "TokenEndpointError(error='TEST_ERROR', "
+            "error_description='Test Description.', "
+            "error_uri='https://example.com/error')"
+        ),
+        id="all",
+    )
+    yield pytest.param(
+        "TEST_ERROR",
+        "Test Description.",
+        None,
+        (
+            "TokenEndpointError(error='TEST_ERROR', "
+            "error_description='Test Description.')"
+        ),
+        id="no error uri",
+    )
+    yield pytest.param(
+        "TEST_ERROR",
+        None,
+        "https://example.com/error",
+        (
+            "TokenEndpointError(error='TEST_ERROR', "
+            "error_uri='https://example.com/error')"
+        ),
+        id="no error description",
+    )
+    yield pytest.param(
+        "TEST_ERROR",
+        None,
+        None,
+        "TokenEndpointError(error='TEST_ERROR')",
+        id="error only",
+    )
+
+
+@pytest.mark.parametrize("error, error_description, error_uri, want", repr_test_cases())
+def test_repr(error, error_description, error_uri, want):
+    # Given
+    error = h2o_authn.error.TokenEndpointError(
+        error=error, error_description=error_description, error_uri=error_uri
+    )
+
+    # When
+    result = repr(error)
+
+    # Then
+    assert result == want
+
+
+def str_test_cases():
+    yield pytest.param(
+        "TEST_ERROR",
+        "Test Description.",
+        "https://example.com/error",
+        "TEST_ERROR: Test Description. (https://example.com/error)",
+        id="all",
+    )
+    yield pytest.param(
+        "TEST_ERROR",
+        "Test Description.",
+        None,
+        "TEST_ERROR: Test Description.",
+        id="no error uri",
+    )
+    yield pytest.param(
+        "TEST_ERROR",
+        None,
+        "https://example.com/error",
+        "TEST_ERROR (https://example.com/error)",
+        id="no error description",
+    )
+    yield pytest.param("TEST_ERROR", None, None, "TEST_ERROR", id="error only")
+
+
+@pytest.mark.parametrize("error, error_description, error_uri, want", str_test_cases())
+def test_str(error, error_description, error_uri, want):
+    # Given
+    error = h2o_authn.error.TokenEndpointError(
+        error=error, error_description=error_description, error_uri=error_uri
+    )
+
+    # When
+    result = str(error)
+
+    # Then
+    assert result == want


### PR DESCRIPTION
Not implementing this causes tracebacks to contain zero information about the error.

Original idea was that the `__repr__` would be enough as it's a fallback when `__str__`
is not implemented. But it's implemented on `Exception` and returns empty message.

Additionally adds test for both repr and str and fix the issue in the repr.

RESOLVES: #81
