### PR TITLE
ci: 💚 attempt remove dependency on the service account

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,11 +16,13 @@ jobs:
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
 
+    permissions:
+      contents: write
+      pull-requests: write
+
     steps:
       - uses: google-github-actions/release-please-action@v4
         id: release
-        with:
-          token: ${{ secrets.RELEASE_PLEASE_GITHUB_TOKEN }}
 
   release-pypi:
     name: Release to PyPI


### PR DESCRIPTION
Release please stopped working on on main (https://github.com/h2oai/authn-py/actions/runs/9584007748/job/26799725722)

With draft PR now working with the release please action, it's not needed.
