### PR TITLE
ci: 👷 drop use of the token for PyPI release

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -32,8 +32,6 @@ jobs:
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
-          verify_metadata: false
+          verify-metadata: false
           verbose: true
-          print_hash: true
+          print-hash: true


### PR DESCRIPTION
This repo should be authorized as the trusted publisher.

Also adjusted config keys to preferred `kebab-case`.

TOKEN itself will be removed once we confirm that this works.
