### PR TITLE
build!: ➖ require httpx >= 0.23

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
   "Topic :: Security",
   "Topic :: Utilities",
 ]
-dependencies = ["httpx>=0.16"]
+dependencies = ["httpx>=0.23"]
 description = "H2O Python Clients Authentication Helpers"
 license = "Apache-2.0"
 name = "h2o-authn"
@@ -34,18 +34,17 @@ packages = ["src/h2o_authn"]
 discovery = ["h2o-cloud-discovery>=1.1,<3.0"]
 
 [[tool.hatch.envs.test.matrix]]
-httpx = ["httpx0.16", "httpx0.21", "httpx0.22", "httpx0.23", "httpx0.24", "httpx0.25", "httpx0.26"]
+httpx = ["httpx0.23", "httpx0.24", "httpx0.25", "httpx0.26", "httpx0.27", "httpx0.28"]
 python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
 [tool.hatch.envs.test.overrides]
 matrix.httpx.dependencies = [
-  {value = "httpx==0.16.*", if = ["httpx0.16"]},
-  {value = "httpx==0.21.*", if = ["httpx0.21"]},
-  {value = "httpx==0.22.*", if = ["httpx0.22"]},
   {value = "httpx==0.23.*", if = ["httpx0.23"]},
   {value = "httpx==0.24.*", if = ["httpx0.24"]},
   {value = "httpx==0.25.*", if = ["httpx0.25"]},
   {value = "httpx==0.26.*", if = ["httpx0.26"]},
+  {value = "httpx==0.27.*", if = ["httpx0.27"]},
+  {value = "httpx==0.27.*", if = ["httpx0.28"]},
 ]
 
 [tool.hatch.envs.test]


### PR DESCRIPTION
We plan to drop support for Python 3.8 that is EOL that will be a breaking change.
So we use this opportunity to also drop support for httpx < 0.23 that do not work with Python 3.13+.

test: Extend test matrix with new versions of httpx
