### PR TITLE
ci: 💚 disable pypi attestations production and upload

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.9"
 
       - name: Install pypa/build
         run: |
@@ -35,3 +35,9 @@ jobs:
           verify-metadata: false
           verbose: true
           print-hash: true
+
+          # Attentions are disabled temporarily. They do seem to work with the
+          # reusable workflow.
+          # - https://github.com/pypa/gh-action-pypi-publish/issues/166
+          # - https://github.com/pypa/gh-action-pypi-publish/issues/283
+          attestations: false

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
+      - name: Set up Python 3.8
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.8"
 
       - name: Install pypa/build
         run: |

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,14 +1,7 @@
 name: Release Python package to PyPI
 
 on:
-# TODO(@zoido): Remove pull_request when latest version is uploaded.
-  pull_request:
   workflow_call:
-
-# TODO(@zoido): Remove permissions when latest version is uploaded.
-permissions:
-  contents: read
-  id-token: write
 
 jobs:
   test:

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,7 +1,14 @@
 name: Release Python package to PyPI
 
 on:
+# TODO(@zoido): Remove pull_request when latest version is uploaded.
+  pull_request:
   workflow_call:
+
+# TODO(@zoido): Remove permissions when latest version is uploaded.
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   test:


### PR DESCRIPTION
They do no seem to work with reusable workflows (see the issues in the comment)


Addresses cause of https://github.com/h2oai/authn-py/issues/104