### PR TITLE
feat: improve compatibility with Python 3.14

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+python 3.14-dev

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,0 @@
-python 3.14-dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,10 @@ classifiers = [
   "Topic :: Security",
   "Topic :: Utilities",
 ]
-dependencies = ["httpx>=0.23"]
+dependencies = [
+  "httpx>=0.23",
+  "httpx>=0.25.1; python_version >= '3.14'",
+]
 description = "H2O Python Clients Authentication Helpers"
 license = "Apache-2.0"
 name = "h2o-authn"
@@ -35,7 +38,11 @@ discovery = ["h2o-cloud-discovery>=1.1,<4.0"]
 
 [[tool.hatch.envs.test.matrix]]
 httpx = ["httpx0.23", "httpx0.24", "httpx0.25", "httpx0.26", "httpx0.27", "httpx0.28"]
-python = ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
+
+[[tool.hatch.envs.test.matrix]]
+httpx = ["httpx0.25", "httpx0.26", "httpx0.27", "httpx0.28"]
+python = ["3.14"]
 
 [tool.hatch.envs.test.overrides]
 matrix.httpx.dependencies = [


### PR DESCRIPTION
`httpcore` that is dependency of the `httpx` causes `AttributeError` for `httpcore<1.0.8`.
(https://github.com/encode/httpcore/blob/master/CHANGELOG.md#version-108-april-11th-2025)

Support for `httpcore>=1.0` was added in `httpc==0.25.1`.
(https://github.com/encode/httpx/blob/master/CHANGELOG.md#0251-3rd-november-2023)

Constraining  httpx for python 3.14  allows to use resolve httpx to versions can use `httpcore` that fixes the issue for python 3.14
